### PR TITLE
Fix typo in SQL chatbot prompt

### DIFF
--- a/GenAI/sql_chatbot.py
+++ b/GenAI/sql_chatbot.py
@@ -96,7 +96,7 @@ def conversational_chat(question):
                     3) Use appropriate filtering, aggregation, and sorting functions to generate insightful results.
                     4) Ensure all queries are correctly formatted and optimized for a PostgreSQL database.
                     5) Be proactive in ensuring the accuracy of your SQL statements and handle any edge cases the user might ask about.
-                    6) Show all the financial metrics in unit of Rupees. USe the correct symbols and units."""
+                    6) Show all the financial metrics in unit of Rupees. Use the correct symbols and units."""
 
     # Create the SQL toolkit
     toolkit = SQLDatabaseToolkit(db=db, llm=llm)


### PR DESCRIPTION
## Summary
- Correct a typographical error in the SQL chatbot guidance text.

## Testing
- `python -m py_compile GenAI/sql_chatbot.py`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a747bb7a90832daccac94df850bb9a